### PR TITLE
Updating Gatsby to v4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gatsby-starter-creative
 
-Gatsby.js V2 starter template based on Creative by startbootstrap
+Gatsby.js V4 starter template based on Creative by startbootstrap
 
 For an overview of the project structure please refer to the [Gatsby documentation - Building with Components](https://www.gatsbyjs.org/docs/building-with-components/).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-starter-creative",
-  "version": "0.0.1",
-  "description": "Gatsby.js V2 starter template based on Creative by startbootstrap",
+  "version": "0.0.2",
+  "description": "Gatsby.js V4 starter template based on Creative by startbootstrap",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/anubhavsrivastava/gatsby-starter-creative.git"
@@ -11,16 +11,18 @@
     "email": "anubhav.srivastava00@gmail.com"
   },
   "dependencies": {
-    "gatsby": "^2.20.2",
-    "gatsby-plugin-manifest": "^2.3.1",
-    "gatsby-plugin-offline": "^3.1.0",
-    "gatsby-plugin-react-helmet": "^3.2.0",
-    "gatsby-plugin-sass": "^2.2.0",
-    "node-sass": "^4.13.1",
+    "gatsby": "^4.2.0",
+    "gatsby-link": "^4.4.0",
+    "gatsby-plugin-manifest": "^4.2.0",
+    "gatsby-plugin-offline": "^5.2.0",
+    "gatsby-plugin-react-helmet": "^5.2.0",
+    "gatsby-plugin-sass": "^5.2.0",
+    "gatsby-react-router-scroll": "^5.4.0",
+    "node-sass": "^6.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^5.2.1",
-    "react-images": "^0.5.19",
+    "react-images": "^1.1.7",
     "react-scrollspy": "^3.4.2",
     "smoothscroll-polyfill": "^0.4.4"
   },
@@ -34,8 +36,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "gh-pages": "^2.0.1",
-    "prettier": "^1.17.0",
+    "gh-pages": "^3.2.3",
+    "prettier": "^2.4.1",
     "rimraf": "^3.0.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-starter-creative",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Gatsby.js V4 starter template based on Creative by startbootstrap",
   "repository": {
     "type": "git",

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Lightbox from 'react-images';
+import Carousel from 'react-images';
 
 class Gallery extends Component {
   constructor() {
@@ -58,21 +58,21 @@ class Gallery extends Component {
 
     const gallery = images.map((obj, i) => {
       return (
-        <div key={obj.src} className="col-lg-4 col-sm-6">
+        <div key={obj.caption} className="col-lg-4 col-sm-6">
           <a
             onClick={e => this.openLightbox(i, e)}
             className="portfolio-box"
-            href={obj.src}
+            href={obj.source.regular}
           >
             <img
               className="img-fluid"
-              src={obj.thumbnail}
+              src={obj.source.thumbnail}
               alt={obj.description}
               title={obj.title}
             />
             <div className="portfolio-box-caption">
               <div className="project-category text-white-50">{obj.title}</div>
-              <div className="project-name">{obj.desc}</div>
+              <div className="project-name">{obj.description}</div>
             </div>
           </a>
         </div>
@@ -89,12 +89,9 @@ class Gallery extends Component {
     return (
       <>
         {this.renderGallery()}
-        <Lightbox
+        <Carousel
           currentImage={this.state.currentImage}
-          images={this.props.images.map(img => {
-            img.caption = `${img.title} - ${img.desc}`;
-            return img;
-          })}
+          views={this.props.images}
           isOpen={this.state.lightboxIsOpen}
           onClickImage={this.handleClickImage}
           onClickNext={this.gotoNext}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -146,10 +146,6 @@ const IndexPage = () => (
       </div>
     </section>
 
-    <section id="portfolio">
-      <Gallery images={img_set} />
-    </section>
-
     <section className="page-section bg-dark text-white">
       <div className="container text-center">
         <h2 className="mb-4">Free Download Gatsby Starter!</h2>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,42 +9,74 @@ import Header from '../components/Header';
 import ContactUs from '../components/ContactUs';
 import Gallery from '../components/Gallery';
 
+// TODO - move to a GraphQL search for import instead of a native import
+import image1Regular from '../assets/images/portfolio/fullsize/1.jpg';
+import image1Thumbnail from '../assets/images/portfolio/thumbnails/1.jpg';
+import image2Regular from '../assets/images/portfolio/fullsize/2.jpg';
+import image2Thumbnail from '../assets/images/portfolio/thumbnails/2.jpg';
+import image3Regular from '../assets/images/portfolio/fullsize/3.jpg';
+import image3Thumbnail from '../assets/images/portfolio/thumbnails/3.jpg';
+import image4Regular from '../assets/images/portfolio/fullsize/4.jpg';
+import image4Thumbnail from '../assets/images/portfolio/thumbnails/4.jpg';
+import image5Regular from '../assets/images/portfolio/fullsize/5.jpg';
+import image5Thumbnail from '../assets/images/portfolio/thumbnails/5.jpg';
+import image6Regular from '../assets/images/portfolio/fullsize/6.jpg';
+import image6Thumbnail from '../assets/images/portfolio/thumbnails/6.jpg';
+
 const img_set = [
   {
-    src: require('../assets/images/portfolio/fullsize/1.jpg'),
-    thumbnail: require('../assets/images/portfolio/thumbnails/1.jpg'),
+    source: {
+      regular: image1Regular,
+      thumbnail: image1Thumbnail,
+    },
+    caption: 'Category - Project Name 1',
+    description: 'Project Name 1',
     title: 'Category',
-    desc: 'Project Name',
   },
   {
-    src: require('../assets/images/portfolio/fullsize/2.jpg'),
-    thumbnail: require('../assets/images/portfolio/thumbnails/2.jpg'),
+    source: {
+      regular: image2Regular,
+      thumbnail: image2Thumbnail,
+    },
+    caption: 'Category - Project Name 2',
+    description: 'Project Name 2',
     title: 'Category',
-    desc: 'Project Name',
   },
   {
-    src: require('../assets/images/portfolio/fullsize/3.jpg'),
-    thumbnail: require('../assets/images/portfolio/thumbnails/3.jpg'),
+    source: {
+      regular: image3Regular,
+      thumbnail: image3Thumbnail,
+    },
+    caption: 'Category - Project Name 3',
+    description: 'Project Name 3',
     title: 'Category',
-    desc: 'Project Name',
   },
   {
-    src: require('../assets/images/portfolio/fullsize/4.jpg'),
-    thumbnail: require('../assets/images/portfolio/thumbnails/4.jpg'),
+    source: {
+      regular: image4Regular,
+      thumbnail: image4Thumbnail,
+    },
+    caption: 'Category - Project Name 4',
+    description: 'Project Name 4',
     title: 'Category',
-    desc: 'Project Name',
   },
   {
-    src: require('../assets/images/portfolio/fullsize/5.jpg'),
-    thumbnail: require('../assets/images/portfolio/thumbnails/5.jpg'),
+    source: {
+      regular: image5Regular,
+      thumbnail: image5Thumbnail,
+    },
+    caption: 'Category - Project Name 5',
+    description: 'Project Name 5',
     title: 'Category',
-    desc: 'Project Name',
   },
   {
-    src: require('../assets/images/portfolio/fullsize/6.jpg'),
-    thumbnail: require('../assets/images/portfolio/thumbnails/6.jpg'),
+    source: {
+      regular: image6Regular,
+      thumbnail: image6Thumbnail,
+    },
+    caption: 'Category - Project Name 6',
+    description: 'Project Name 6',
     title: 'Category',
-    desc: 'Project Name',
   },
 ];
 const IndexPage = () => (
@@ -144,6 +176,10 @@ const IndexPage = () => (
           </div>
         </div>
       </div>
+    </section>
+
+    <section id="portfolio">
+      <Gallery images={img_set} />
     </section>
 
     <section className="page-section bg-dark text-white">


### PR DESCRIPTION
Updates Gatsby to v4.2.0.

Updates selected additional packages to newer versions to account for Gatsby version change.

This update does not change any of the SASS deprecation warnings and any other warnings.  Those will be in a future PR.

This also temporarily disables the Gallery call, as the package 'react-images' is not functioning properly with Node 16.7.0, and per its npmjs.com page, the package is highly deprecated and should be replaced with a maintained package.  This will also need to be reviewed in light of React v16 being out of date as well.